### PR TITLE
Fixing version injection bug in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Install, build, and upload your site
               uses: withastro/action@v2.0.1
               with:
-                  package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+                  package-manager: pnpm
 
     deploy:
         needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,6 @@ jobs:
               uses: actions/checkout@v4
             - name: Install, build, and upload your site
               uses: withastro/action@v2.0.1
-              with:
-                  package-manager: pnpm
 
     deploy:
         needs: build

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "website",
     "type": "module",
     "version": "0.3",
+    "packageManager":"^pnpm@9.4.0",
     "scripts": {
         "stamp": "echo \"COMMIT_HASH=$(git rev-parse --short HEAD)\"> .env && echo \"VERSION=$(node -p \"require('./package.json').version\")\">>.env",
         "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "website",
     "type": "module",
     "version": "0.3",
-    "packageManager":"^pnpm@9.4.0",
+    "packageManager":"pnpm@9.4.0",
     "scripts": {
         "stamp": "echo \"COMMIT_HASH=$(git rev-parse --short HEAD)\"> .env && echo \"VERSION=$(node -p \"require('./package.json').version\")\">>.env",
         "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "0.3",
     "packageManager":"pnpm@9.4.0",
     "scripts": {
-        "stamp": "echo \"COMMIT_HASH=$(git rev-parse --short HEAD)\"> .env && echo \"VERSION=0.3\">>.env",
+        "stamp": "echo \"COMMIT_HASH=$(git rev-parse --short HEAD)\"> .env && echo \"WEBSITE_VERSION=$(node -p \"require('./package.json').version\")\">>.env",
         "dev": "astro dev",
         "start": "astro dev",
         "build": "pnpm stamp && astro build",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "0.3",
     "packageManager":"pnpm@9.4.0",
     "scripts": {
-        "stamp": "echo \"COMMIT_HASH=$(git rev-parse --short HEAD)\"> .env && echo \"VERSION=$(node -p \"require('./package.json').version\")\">>.env",
+        "stamp": "echo \"COMMIT_HASH=$(git rev-parse --short HEAD)\"> .env && echo \"VERSION=0.3\">>.env",
         "dev": "astro dev",
         "start": "astro dev",
         "build": "pnpm stamp && astro build",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@
  */
 import GitBranch from "~icons/octicon/git-branch-16";
 const commitHash = await import.meta.env.COMMIT_HASH;
-const version = await import.meta.env.VERSION;
+const version = await import.meta.env.WEBSITE_VERSION;
 ---
 
 <footer class="footer footer-center p-4 text-base-content rounded-md">


### PR DESCRIPTION
It looks like the `VERSION` variable I was writing to an environment variable in CI to display the website version in `Footer.svelte` may have been getting overwritten by something somewhere else. This PR basically just changes the environment variable name to `WEBSITE_VERSION`, which has seemed to resolve the issue.