### PR TITLE
Conformal Maps Post Style Fix

### DIFF
--- a/src/content/posts/conformal-maps.mdx
+++ b/src/content/posts/conformal-maps.mdx
@@ -12,9 +12,7 @@ fullWidth: true
 
 import ExternalPage from "@components/ExternalPage.svelte";
 
-<div class="py-2">
-    <ExternalPage client:load link="https://alexbustos.com/phys-6124" />
-</div>
+<ExternalPage client:load link="https://alexbustos.com/phys-6124" />
 
 ### Overview
 


### PR DESCRIPTION
Small PR to remove vertical padding from `ExternalPage` component on conformal maps post.