### PR TITLE
Left aligning text in Posts and Notes.

### DIFF
--- a/src/layouts/MarkdownNoteLayout.astro
+++ b/src/layouts/MarkdownNoteLayout.astro
@@ -15,7 +15,7 @@ const notes = (await getCollection("notes")).filter((note) => !note.data.draft);
 <NoteMenu notes={notes}>
     <BaseLayout pageTitle={data.title}>
         <article
-            class="prose prose-img:rounded-md prose-img:my-0 prose-img:w-full text-justify leading-snug mx-auto
+            class="prose prose-img:rounded-md prose-img:my-0 prose-img:w-full leading-snug mx-auto
             pb-20 prose-h3:m-0 w-full max-w-none"
         >
             <h2 class="text-left py-0 px-0 my-1">

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -14,7 +14,7 @@ const { data } = Astro.props;
 
 <BaseLayout pageTitle={data.title} fullWidth={data.fullWidth}>
     <article
-        class={`prose prose-img:rounded-md prose-img:my-0 text-justify leading-snug mx-auto pb-20 prose-h3:m-0 ${data.fullWidth ? "w-full max-w-none" : ""}`}
+        class={`prose prose-img:rounded-md prose-img:my-0 leading-snug mx-auto pb-20 prose-h3:m-0 ${data.fullWidth ? "w-full max-w-none" : ""}`}
     >
         <h2 class="text-left py-0 px-0 my-1">
             {data.title}


### PR DESCRIPTION
This PR:
- un-justifies text in articles for MarkdownPosts and MarkdownNotes. I think this looks a little better