### PR TITLE
Remove default max width on articles, limit image height accordingly

### DIFF
--- a/src/components/ClickableImage.svelte
+++ b/src/components/ClickableImage.svelte
@@ -43,12 +43,12 @@ set to `below` to permanently display the caption below the image.
 <!-- default image -->
 <button
     on:click={toggleModal}
-    class="relative cursor-pointer overflow-hidden rounded-md"
+    class="relative cursor-pointer overflow-hidden rounded-md mx-auto block"
     on:mouseenter={() => (hovered = true)}
     on:mouseleave={() => (hovered = false)}
 >
     <slot />
-    <!-- if hoverCaption is defined, only show the caption on hover. otherwise, just show the caption without any animation -->
+    <!-- if `hoverCaption` is defined, only show the caption on hover. otherwise, just show the caption without any animation -->
     {#if hovered && caption && captionMode === "hover"}
         <div
             class="absolute bottom-0 left-0 h-auto w-full bg-black bg-opacity-70 p-2 rounded-b-md text-white flex justify-start items-center text-left"
@@ -77,7 +77,7 @@ set to `below` to permanently display the caption below the image.
                 <img
                     src={imgSrc}
                     alt={caption}
-                    class="w-auto h-auto max-h-full object-contain"
+                    class="w-auto h-auto max-h-full object-contain rounded-md not-prose"
                 />
             {/if}
             {#if caption}

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -14,7 +14,7 @@ const { data } = Astro.props;
 
 <BaseLayout pageTitle={data.title} fullWidth={data.fullWidth}>
     <article
-        class={`prose prose-img:rounded-md prose-img:my-0 leading-snug mx-auto pb-20 prose-h3:m-0 ${data.fullWidth ? "w-full max-w-none" : ""}`}
+        class={`prose prose-img:rounded-md prose-img:my-0 leading-snug mx-auto pb-20 prose-h3:m-0 max-w-none ${data.fullWidth ? "w-full" : ""}`}
     >
         <h2 class="text-left py-0 px-0 my-1">
             {data.title}

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -14,7 +14,7 @@ const { data } = Astro.props;
 
 <BaseLayout pageTitle={data.title} fullWidth={data.fullWidth}>
     <article
-        class={`prose prose-img:rounded-md prose-img:my-0 leading-snug mx-auto pb-20 prose-h3:m-0 max-w-none ${data.fullWidth ? "w-full" : ""}`}
+        class={`prose prose-img:rounded-md prose-img:my-0 prose-img:max-h-[85vh] prose-img:w-auto prose-img:mx-auto leading-snug mx-auto pb-20 prose-h3:m-0 max-w-none ${data.fullWidth ? "w-full" : ""}`}
     >
         <h2 class="text-left py-0 px-0 my-1">
             {data.title}


### PR DESCRIPTION
This PR:
- removes the default width computed by TailwindCSS Typography and instead allows posts to just fill to the parent div's width. I think I like how this looks better, since it always aligns with the width of the navigation bar.
- updates images to be limited to, at a maximum, `85vh` in posts. 